### PR TITLE
#9 Fixed memory leak

### DIFF
--- a/api/statistics.go
+++ b/api/statistics.go
@@ -59,6 +59,8 @@ func GetStatistics(c *gin.Context) {
 		})
 		return
 	}
+	payload.From = params.From
+	payload.To = params.To
 
 	c.JSON(http.StatusOK, payload)
 }

--- a/api/statistics.go
+++ b/api/statistics.go
@@ -72,7 +72,7 @@ func getStatistics(params *operations.GetStatisticsParams, sb controller.Statist
 	if params.From.After(cutoffTime) {
 		// case 1: time frame within "in-memory" interval (e.g. last 30 minutes)
 		// -> return in-memory object
-		mergedStatistics = *sb.GetStatistics()
+		mergedStatistics = sb.GetStatistics()
 
 	} else {
 		var statistics []operations.Statistics
@@ -91,7 +91,7 @@ func getStatistics(params *operations.GetStatisticsParams, sb controller.Statist
 			if statistics == nil {
 				statistics = []operations.Statistics{}
 			}
-			statistics = append(statistics, *sb.GetStatistics())
+			statistics = append(statistics, sb.GetStatistics())
 		}
 
 		mergedStatistics = operations.Statistics{

--- a/api/statistics_test.go
+++ b/api/statistics_test.go
@@ -58,8 +58,8 @@ func (m *MockStatisticsInterface) GetCutoffTime() time.Time {
 	return m.CutoffTime
 }
 
-func (m *MockStatisticsInterface) GetStatistics() *operations.Statistics {
-	return m.Statistics
+func (m *MockStatisticsInterface) GetStatistics() operations.Statistics {
+	return *m.Statistics
 }
 
 func (m *MockStatisticsInterface) AddEvent(event operations.Event) {

--- a/controller/statistics.go
+++ b/controller/statistics.go
@@ -15,7 +15,7 @@ var statisticsBucketInstance *statisticsBucket
 
 type statisticsBucket struct {
 	StatisticsRepo  db.StatisticsRepo
-	Statistics      *operations.Statistics
+	Statistics      operations.Statistics
 	bucketTimer     *time.Ticker
 	uniqueSequences map[string]bool
 	logger          keptn.LoggerInterface
@@ -54,7 +54,7 @@ func (sb *statisticsBucket) GetCutoffTime() time.Time {
 }
 
 // GetStatistics godoc
-func (sb *statisticsBucket) GetStatistics() *operations.Statistics {
+func (sb *statisticsBucket) GetStatistics() operations.Statistics {
 	return sb.Statistics
 }
 
@@ -105,7 +105,7 @@ func (sb *statisticsBucket) storeCurrentBucket() {
 	defer sb.lock.Unlock()
 	sb.logger.Info(fmt.Sprintf("Storing statistics for time frame %s - %s\n\n", sb.Statistics.From.String(), sb.Statistics.To.String()))
 	sb.Statistics.To = time.Now().Round(time.Second)
-	if err := sb.StatisticsRepo.StoreStatistics(*sb.Statistics); err != nil {
+	if err := sb.StatisticsRepo.StoreStatistics(sb.Statistics); err != nil {
 		sb.logger.Error(fmt.Sprintf("Could not store statistics: " + err.Error()))
 	}
 	sb.logger.Info(fmt.Sprintf("Statistics stored successfully"))
@@ -116,7 +116,7 @@ func (sb *statisticsBucket) createNewBucket() {
 	defer sb.lock.Unlock()
 	sb.cutoffTime = time.Now().Round(time.Second)
 	sb.uniqueSequences = map[string]bool{}
-	sb.Statistics = &operations.Statistics{
+	sb.Statistics = operations.Statistics{
 		From: time.Now().Round(time.Second),
 	}
 }

--- a/controller/statistics.go
+++ b/controller/statistics.go
@@ -28,11 +28,9 @@ func GetStatisticsBucketInstance() *statisticsBucket {
 	if statisticsBucketInstance == nil {
 		env := config.GetConfig()
 		statisticsBucketInstance = &statisticsBucket{
-			StatisticsRepo: &db.StatisticsMongoDBRepo{
-				DbConnection: &db.MongoDBConnection{},
-			},
-			logger:        keptn.NewLogger("", "", "statistics service"),
-			nextGenEvents: env.NextGenEvents,
+			StatisticsRepo: &db.StatisticsMongoDBRepo{},
+			logger:         keptn.NewLogger("", "", "statistics service"),
+			nextGenEvents:  env.NextGenEvents,
 		}
 
 		statisticsBucketInstance.createNewBucket()

--- a/controller/statistics_interface.go
+++ b/controller/statistics_interface.go
@@ -11,7 +11,7 @@ type StatisticsInterface interface {
 	// GetCutoffTime godoc
 	GetCutoffTime() time.Time
 	// GetStatistics godoc
-	GetStatistics() *operations.Statistics
+	GetStatistics() operations.Statistics
 	// AddEvent godoc
 	AddEvent(event operations.Event)
 	// GetRepo godoc

--- a/controller/statistics_test.go
+++ b/controller/statistics_test.go
@@ -41,7 +41,6 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 	type fields struct {
 		StatisticsRepo  db.StatisticsRepo
 		Statistics      operations.Statistics
-		bucketTimer     *time.Ticker
 		uniqueSequences map[string]bool
 		logger          keptn.LoggerInterface
 		lock            sync.Mutex
@@ -71,7 +70,6 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 						},
 					},
 				},
-				bucketTimer: nil,
 				uniqueSequences: map[string]bool{
 					"test-context": true,
 				},
@@ -86,7 +84,6 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 			sb := &statisticsBucket{
 				StatisticsRepo:  tt.fields.StatisticsRepo,
 				Statistics:      tt.fields.Statistics,
-				bucketTimer:     tt.fields.bucketTimer,
 				uniqueSequences: tt.fields.uniqueSequences,
 				logger:          tt.fields.logger,
 				lock:            tt.fields.lock,
@@ -149,7 +146,6 @@ func Test_statisticsBucket_storeCurrentBucket(t *testing.T) {
 			sb := &statisticsBucket{
 				StatisticsRepo:  tt.fields.StatisticsRepo,
 				Statistics:      tt.fields.Statistics,
-				bucketTimer:     tt.fields.bucketTimer,
 				uniqueSequences: tt.fields.uniqueSequences,
 				logger:          tt.fields.logger,
 				lock:            tt.fields.lock,
@@ -401,7 +397,6 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 			sb := &statisticsBucket{
 				StatisticsRepo:  tt.fields.StatisticsRepo,
 				Statistics:      tt.fields.Statistics,
-				bucketTimer:     tt.fields.bucketTimer,
 				uniqueSequences: tt.fields.uniqueSequences,
 				logger:          tt.fields.logger,
 				lock:            tt.fields.lock,

--- a/controller/statistics_test.go
+++ b/controller/statistics_test.go
@@ -40,7 +40,7 @@ func (m *MockStatisticsRepo) DeleteStatistics(from, to time.Time) error {
 func Test_statisticsBucket_createNewBucket(t *testing.T) {
 	type fields struct {
 		StatisticsRepo  db.StatisticsRepo
-		Statistics      *operations.Statistics
+		Statistics      operations.Statistics
 		bucketTimer     *time.Ticker
 		uniqueSequences map[string]bool
 		logger          keptn.LoggerInterface
@@ -54,20 +54,15 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 		{
 			name: "create statistics bucket - initially nil",
 			fields: fields{
-				StatisticsRepo:  nil,
-				Statistics:      nil,
-				bucketTimer:     nil,
-				uniqueSequences: nil,
-				logger:          nil,
-				lock:            sync.Mutex{},
-				cutoffTime:      time.Time{},
+				lock:       sync.Mutex{},
+				cutoffTime: time.Time{},
 			},
 		},
 		{
 			name: "create statistics bucket - replace previous bucket",
 			fields: fields{
 				StatisticsRepo: nil,
-				Statistics: &operations.Statistics{
+				Statistics: operations.Statistics{
 					From: time.Time{},
 					To:   time.Time{},
 					Projects: map[string]*operations.Project{
@@ -99,9 +94,6 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 			}
 			sb.createNewBucket()
 
-			if sb.Statistics == nil {
-				t.Error("createNewBucket() failed: Statistics == nil")
-			}
 			if len(sb.Statistics.Projects) > 0 {
 				t.Errorf("Statistics have not been replaced properly. Got length = %d", len(sb.Statistics.Projects))
 			}
@@ -115,7 +107,7 @@ func Test_statisticsBucket_createNewBucket(t *testing.T) {
 func Test_statisticsBucket_storeCurrentBucket(t *testing.T) {
 	type fields struct {
 		StatisticsRepo  *MockStatisticsRepo
-		Statistics      *operations.Statistics
+		Statistics      operations.Statistics
 		bucketTimer     *time.Ticker
 		uniqueSequences map[string]bool
 		logger          keptn.LoggerInterface
@@ -134,7 +126,7 @@ func Test_statisticsBucket_storeCurrentBucket(t *testing.T) {
 					StoreStatisticsFunc:  nil,
 					DeleteStatisticsFunc: nil,
 				},
-				Statistics: &operations.Statistics{
+				Statistics: operations.Statistics{
 					From: time.Time{},
 					To:   time.Time{},
 					Projects: map[string]*operations.Project{
@@ -164,7 +156,7 @@ func Test_statisticsBucket_storeCurrentBucket(t *testing.T) {
 				cutoffTime:      tt.fields.cutoffTime,
 			}
 			tt.fields.StatisticsRepo.StoreStatisticsFunc = func(statistics operations.Statistics) error {
-				diff := deep.Equal(statistics, *sb.Statistics)
+				diff := deep.Equal(statistics, sb.Statistics)
 				if len(diff) > 0 {
 					t.Error("StatisticsRepo did not receive expected value")
 					for _, d := range diff {
@@ -182,7 +174,7 @@ func Test_statisticsBucket_storeCurrentBucket(t *testing.T) {
 func Test_statisticsBucket_AddEvent(t *testing.T) {
 	type fields struct {
 		StatisticsRepo  db.StatisticsRepo
-		Statistics      *operations.Statistics
+		Statistics      operations.Statistics
 		bucketTimer     *time.Ticker
 		uniqueSequences map[string]bool
 		logger          keptn.LoggerInterface
@@ -196,14 +188,14 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 		name                    string
 		fields                  fields
 		args                    args
-		expectedStatistics      *operations.Statistics
+		expectedStatistics      operations.Statistics
 		expectedUniqueSequences map[string]bool
 	}{
 		{
 			name: "Add event to empty bucket",
 			fields: fields{
 				StatisticsRepo: nil,
-				Statistics: &operations.Statistics{
+				Statistics: operations.Statistics{
 					From:     time.Time{},
 					To:       time.Time{},
 					Projects: nil,
@@ -225,7 +217,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 					Source:         "my-keptn-service",
 				},
 			},
-			expectedStatistics: &operations.Statistics{
+			expectedStatistics: operations.Statistics{
 				From: time.Time{},
 				To:   time.Time{},
 				Projects: map[string]*operations.Project{
@@ -259,7 +251,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 			name: "Add event to existing bucket",
 			fields: fields{
 				StatisticsRepo: nil,
-				Statistics: &operations.Statistics{
+				Statistics: operations.Statistics{
 					From: time.Time{},
 					To:   time.Time{},
 					Projects: map[string]*operations.Project{
@@ -302,7 +294,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 					Source:         "my-keptn-service",
 				},
 			},
-			expectedStatistics: &operations.Statistics{
+			expectedStatistics: operations.Statistics{
 				From: time.Time{},
 				To:   time.Time{},
 				Projects: map[string]*operations.Project{
@@ -336,7 +328,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 			name: "Add event to existing bucket for second event of same context",
 			fields: fields{
 				StatisticsRepo: nil,
-				Statistics: &operations.Statistics{
+				Statistics: operations.Statistics{
 					From: time.Time{},
 					To:   time.Time{},
 					Projects: map[string]*operations.Project{
@@ -373,7 +365,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 					Source:         "my-keptn-service",
 				},
 			},
-			expectedStatistics: &operations.Statistics{
+			expectedStatistics: operations.Statistics{
 				From: time.Time{},
 				To:   time.Time{},
 				Projects: map[string]*operations.Project{

--- a/db/mongodb_connection.go
+++ b/db/mongodb_connection.go
@@ -28,6 +28,7 @@ func (m *MongoDBConnection) EnsureDBConnection() error {
 	mutex.Lock()
 	defer mutex.Unlock()
 	var err error
+	// attention: not calling the cancel() function likely causes memory leaks
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if m.Client == nil {

--- a/db/mongodb_connection.go
+++ b/db/mongodb_connection.go
@@ -28,10 +28,12 @@ func (m *MongoDBConnection) EnsureDBConnection() error {
 	mutex.Lock()
 	defer mutex.Unlock()
 	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	if m.Client == nil {
 		fmt.Println("No MongoDB client has been initialized yet. Creating a new one.")
 		return m.connectMongoDBClient()
-	} else if err = m.Client.Ping(context.TODO(), nil); err != nil {
+	} else if err = m.Client.Ping(ctx, nil); err != nil {
 		fmt.Println("MongoDB client lost connection. Attempt reconnect.")
 		return m.connectMongoDBClient()
 	}
@@ -46,7 +48,6 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-
 	defer cancel()
 
 	err = m.Client.Connect(ctx)

--- a/db/statistics_mongodb_repo.go
+++ b/db/statistics_mongodb_repo.go
@@ -11,20 +11,20 @@ import (
 const keptnStatsCollection = "keptn-stats"
 
 type StatisticsMongoDBRepo struct {
-	DbConnection MongoDBConnection
+	DbConnection    *MongoDBConnection
+	statsCollection *mongo.Collection
 }
 
 // GetStatistics godoc
-func (s StatisticsMongoDBRepo) GetStatistics(from, to time.Time) ([]operations.Statistics, error) {
-	collection, err := s.getCollection()
+func (s *StatisticsMongoDBRepo) GetStatistics(from, to time.Time) ([]operations.Statistics, error) {
+	err := s.getCollection()
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 
-	//sortOptions := options.Find().SetSort(bson.D{{"from", 1}}).
 	searchOptions := bson.M{}
 
 	searchOptions["from"] = bson.M{
@@ -34,7 +34,7 @@ func (s StatisticsMongoDBRepo) GetStatistics(from, to time.Time) ([]operations.S
 		"$lt": to,
 	}
 
-	cur, err := collection.Find(ctx, searchOptions)
+	cur, err := s.statsCollection.Find(ctx, searchOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -58,16 +58,16 @@ func (s StatisticsMongoDBRepo) GetStatistics(from, to time.Time) ([]operations.S
 }
 
 // StoreStatistics godoc
-func (s StatisticsMongoDBRepo) StoreStatistics(statistics operations.Statistics) error {
-	collection, err := s.getCollection()
+func (s *StatisticsMongoDBRepo) StoreStatistics(statistics operations.Statistics) error {
+	err := s.getCollection()
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 
-	_, err = collection.InsertOne(ctx, statistics)
+	_, err = s.statsCollection.InsertOne(ctx, statistics)
 	if err != nil {
 		return err
 	}
@@ -76,13 +76,13 @@ func (s StatisticsMongoDBRepo) StoreStatistics(statistics operations.Statistics)
 }
 
 // DeleteStatistics godoc
-func (s StatisticsMongoDBRepo) DeleteStatistics(from, to time.Time) error {
-	collection, err := s.getCollection()
+func (s *StatisticsMongoDBRepo) DeleteStatistics(from, to time.Time) error {
+	err := s.getCollection()
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 	searchOptions := bson.M{}
 
@@ -93,16 +93,18 @@ func (s StatisticsMongoDBRepo) DeleteStatistics(from, to time.Time) error {
 		"$lt": to.String(),
 	}
 
-	_, err = collection.DeleteMany(ctx, searchOptions)
+	_, err = s.statsCollection.DeleteMany(ctx, searchOptions)
 	return err
 }
 
-func (s StatisticsMongoDBRepo) getCollection() (*mongo.Collection, error) {
+func (s *StatisticsMongoDBRepo) getCollection() error {
 	err := s.DbConnection.EnsureDBConnection()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	collection := s.DbConnection.Client.Database(databaseName).Collection(keptnStatsCollection)
-	return collection, nil
+	if s.statsCollection == nil {
+		s.statsCollection = s.DbConnection.Client.Database(databaseName).Collection(keptnStatsCollection)
+	}
+	return nil
 }

--- a/db/statistics_mongodb_repo.go
+++ b/db/statistics_mongodb_repo.go
@@ -11,7 +11,7 @@ import (
 const keptnStatsCollection = "keptn-stats"
 
 type StatisticsMongoDBRepo struct {
-	DbConnection    *MongoDBConnection
+	DbConnection    MongoDBConnection
 	statsCollection *mongo.Collection
 }
 


### PR DESCRIPTION
Closes #9 

Changes made:

wherever possible, use values instead of pointers to avoid keeping references in memory
don't use time.Ticker within goroutine (see https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082)

make sure that the `cancel()` function is called when creating a context for the mongodb calls

With these changes, the memory usage looks as follows:

![Screenshot 2020-11-09 at 16 42 22](https://user-images.githubusercontent.com/2143586/98562686-9ab0e100-22aa-11eb-8a42-9a37753d2c9f.png)
